### PR TITLE
fix(types): make types mutable

### DIFF
--- a/src/array/index.spec.ts
+++ b/src/array/index.spec.ts
@@ -32,13 +32,10 @@ describe("array", () => {
   it("adds primitive types", () => {
     const type = array({ of: [boolean()] });
 
-    const value: ValidateShape<
-      InferValue<typeof type>,
-      readonly boolean[]
-    > = [];
+    const value: ValidateShape<InferValue<typeof type>, boolean[]> = [];
     const parsedValue: ValidateShape<
       InferParsedValue<typeof type>,
-      readonly boolean[]
+      boolean[]
     > = type.parse(value);
 
     expect(parsedValue).toEqual(value);
@@ -75,7 +72,7 @@ describe("array", () => {
 
     const value: ValidateShape<
       InferValue<typeof type>,
-      ReadonlyArray<{
+      Array<{
         _key: string;
         foo: boolean;
       }>
@@ -85,7 +82,7 @@ describe("array", () => {
     ];
     const parsedValue: ValidateShape<
       InferParsedValue<typeof type>,
-      ReadonlyArray<{
+      Array<{
         _key: string;
         foo: boolean;
       }>
@@ -143,7 +140,7 @@ describe("array", () => {
 
     const value: ValidateShape<
       InferValue<typeof type>,
-      ReadonlyArray<
+      Array<
         | {
             _key: string;
             foo: boolean;
@@ -159,7 +156,7 @@ describe("array", () => {
     ];
     const parsedValue: ValidateShape<
       InferParsedValue<typeof type>,
-      ReadonlyArray<
+      Array<
         | {
             _key: string;
             foo: boolean;
@@ -183,12 +180,10 @@ describe("array", () => {
       ],
     });
 
-    const value: ValidateShape<InferValue<typeof type>, readonly boolean[]> = [
-      true,
-    ];
+    const value: ValidateShape<InferValue<typeof type>, boolean[]> = [true];
     const resolvedValue: ValidateShape<
       InferResolvedValue<typeof type>,
-      readonly string[]
+      string[]
     > = type.resolve(value);
 
     expect(resolvedValue).toEqual(["foo"]);
@@ -205,11 +200,11 @@ describe("array", () => {
 
     const value: ValidateShape<
       InferValue<typeof type>,
-      readonly [boolean, boolean, ...boolean[]]
+      [boolean, boolean, ...boolean[]]
     > = [true, false];
     const parsedValue: ValidateShape<
       InferParsedValue<typeof type>,
-      readonly [boolean, boolean, ...boolean[]]
+      [boolean, boolean, ...boolean[]]
     > = type.parse(value);
 
     expect(parsedValue).toEqual(value);
@@ -230,17 +225,11 @@ describe("array", () => {
 
     const value: ValidateShape<
       InferValue<typeof type>,
-      | readonly []
-      | readonly [boolean]
-      | readonly [boolean, boolean]
-      | readonly [boolean, boolean, boolean]
+      [] | [boolean] | [boolean, boolean] | [boolean, boolean, boolean]
     > = [true, false, true];
     const parsedValue: ValidateShape<
       InferParsedValue<typeof type>,
-      | readonly []
-      | readonly [boolean]
-      | readonly [boolean, boolean]
-      | readonly [boolean, boolean, boolean]
+      [] | [boolean] | [boolean, boolean] | [boolean, boolean, boolean]
     > = type.parse(value);
 
     expect(parsedValue).toEqual(value);
@@ -259,13 +248,13 @@ describe("array", () => {
 
     expect(rule.length).toHaveBeenCalledWith(2);
 
-    const value: ValidateShape<
-      InferValue<typeof type>,
-      readonly [boolean, boolean]
-    > = [true, false];
+    const value: ValidateShape<InferValue<typeof type>, [boolean, boolean]> = [
+      true,
+      false,
+    ];
     const parsedValue: ValidateShape<
       InferParsedValue<typeof type>,
-      readonly [boolean, boolean]
+      [boolean, boolean]
     > = type.parse(value);
 
     expect(parsedValue).toEqual(value);
@@ -323,7 +312,7 @@ describe("array", () => {
           const elements: ValidateShape<
             typeof value,
             PartialDeep<
-              ReadonlyArray<
+              Array<
                 | {
                     _key: string;
                     foo: boolean;

--- a/src/object/index.spec.ts
+++ b/src/object/index.spec.ts
@@ -174,14 +174,16 @@ describe("object", () => {
     }));
 
   it("mocks the same value with the same path", () => {
-    const objectDef = () => ({
-      fields: [
-        {
-          name: "foo",
-          type: string(),
-        },
-      ] as const,
-    });
+    const objectDef = () => {
+      const field = {
+        name: "foo",
+        type: string(),
+      };
+
+      const fields: [typeof field] = [field];
+
+      return { fields };
+    };
 
     expect(object(objectDef()).mock(faker)).toEqual(
       object(objectDef()).mock(faker)

--- a/src/objectNamed/index.spec.ts
+++ b/src/objectNamed/index.spec.ts
@@ -242,15 +242,16 @@ describe("object", () => {
     }));
 
   it("mocks the same value with the same path", () => {
-    const objectDef = () => ({
-      name: "foo",
-      fields: [
-        {
-          name: "foo",
-          type: string(),
-        },
-      ] as const,
-    });
+    const objectDef = () => {
+      const field = {
+        name: "foo",
+        type: string(),
+      };
+
+      const fields: [typeof field] = [field];
+
+      return { name: "foo", fields };
+    };
 
     expect(objectNamed(objectDef()).mock(faker)).toEqual(
       objectNamed(objectDef()).mock(faker)

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,10 +11,10 @@ export type TupleOfLength<
   T,
   Min extends number = number,
   Max extends number = number,
-  Result extends readonly T[] = readonly []
+  Result extends T[] = []
 > = Result["length"] extends Min
   ? number extends Max
-    ? readonly [...Result, ...T[]]
+    ? [...Result, ...T[]]
     : Result["length"] extends Max
     ? Result
     :
@@ -23,9 +23,9 @@ export type TupleOfLength<
             T,
             [T, ...Result]["length"] & number,
             Max,
-            readonly [T, ...Result]
+            [T, ...Result]
           >
-  : TupleOfLength<T, Min, Max, readonly [T, ...Result]>;
+  : TupleOfLength<T, Min, Max, [T, ...Result]>;
 
 export const zodUnion = <Zods extends z.ZodTypeAny>(zods: Zods[]): Zods =>
   zods.length === 1


### PR DESCRIPTION
fixes saiichihashimoto/sanity-typed-schema-builder#156 by removing `readonly` from `TupleOfLength`