### PR TITLE
fix(types): document _id is not guaranteed to be a UUID

### DIFF
--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -74,7 +74,7 @@ interface ExtraZodFields<DocumentName extends string> {
 
 const extraZodFields = <DocumentNames extends string>(name: DocumentNames) => ({
   _createdAt: z.string().transform((v) => new Date(v)),
-  _id: z.string().uuid(),
+  _id: z.string(),
   _rev: z.string(),
   _type: z.literal(name),
   _updatedAt: z.string().transform((v) => new Date(v)),


### PR DESCRIPTION
There are 2 cases where _id is not a valid UUID, which causes parsing to fail, despite a valid document:

1) Drafts. (draft.some-uuid)
2) String id set via the structure builder:
```typescript
S.document()
.schemaType('header')
.title('Site Header')
.documentId('header')
.views([
	S.view.form().icon(PencilSquareIcon),
	S.view
		.component(iframePreview)
		.options({ previewURL })
		.icon(EyeIcon)
		.title('Web Preview'),
]),
```

This PR replaces the UUID type for _id on documents with a regular string.