### PR TITLE
fix(types): hotspot and crop can be undefined on images

### DIFF
--- a/src/image/index.spec.ts
+++ b/src/image/index.spec.ts
@@ -70,6 +70,24 @@ describe("image", () => {
     expect(parsedValue).toEqual(value);
   });
 
+  it("allows undefined hotspot and crop on new images", () => {
+    const type = image({ hotspot: true });
+
+    const value: ValidateShape<InferValue<typeof type>, SanityImage<true>> = {
+      _type: "image",
+      asset: {
+        _type: "reference",
+        _ref: "image-S2od0Kd5mpOa4Y0Wlku8RvXE",
+      },
+    };
+    const parsedValue: ValidateShape<
+      InferParsedValue<typeof type>,
+      SanityImage<true>
+    > = type.parse(value);
+
+    expect(parsedValue).toEqual(value);
+  });
+
   it("adds fields", () => {
     const type = image({
       fields: [

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -28,8 +28,8 @@ export type SanityImage<Hotspot extends boolean> = Hotspot extends false
   : {
       _type: "image";
       asset: SanityReference;
-      crop: ImageCrop;
-      hotspot: ImageHotspot;
+      crop?: ImageCrop;
+      hotspot?: ImageHotspot;
     };
 
 type ExtraZodFields<Hotspot extends boolean> = Hotspot extends false
@@ -40,20 +40,24 @@ type ExtraZodFields<Hotspot extends boolean> = Hotspot extends false
   : {
       _type: z.ZodLiteral<"image">;
       asset: ReturnType<typeof referenceZod<false>>;
-      crop: z.ZodObject<{
-        _type: z.ZodOptional<z.ZodLiteral<"sanity.imageCrop">>;
-        bottom: z.ZodNumber;
-        left: z.ZodNumber;
-        right: z.ZodNumber;
-        top: z.ZodNumber;
-      }>;
-      hotspot: z.ZodObject<{
-        _type: z.ZodOptional<z.ZodLiteral<"sanity.imageHotspot">>;
-        height: z.ZodNumber;
-        width: z.ZodNumber;
-        x: z.ZodNumber;
-        y: z.ZodNumber;
-      }>;
+      crop: z.ZodOptional<
+        z.ZodObject<{
+          _type: z.ZodOptional<z.ZodLiteral<"sanity.imageCrop">>;
+          bottom: z.ZodNumber;
+          left: z.ZodNumber;
+          right: z.ZodNumber;
+          top: z.ZodNumber;
+        }>
+      >;
+      hotspot: z.ZodOptional<
+        z.ZodObject<{
+          _type: z.ZodOptional<z.ZodLiteral<"sanity.imageHotspot">>;
+          height: z.ZodNumber;
+          width: z.ZodNumber;
+          x: z.ZodNumber;
+          y: z.ZodNumber;
+        }>
+      >;
     };
 
 const extraZodFields = <Hotspot extends boolean>(
@@ -65,20 +69,24 @@ const extraZodFields = <Hotspot extends boolean>(
     ...(!hotspot
       ? {}
       : {
-          crop: z.object({
-            _type: z.literal("sanity.imageCrop").optional(),
-            bottom: z.number(),
-            left: z.number(),
-            right: z.number(),
-            top: z.number(),
-          }),
-          hotspot: z.object({
-            _type: z.literal("sanity.imageHotspot").optional(),
-            height: z.number(),
-            width: z.number(),
-            x: z.number(),
-            y: z.number(),
-          }),
+          crop: z
+            .object({
+              _type: z.literal("sanity.imageCrop").optional(),
+              bottom: z.number(),
+              left: z.number(),
+              right: z.number(),
+              top: z.number(),
+            })
+            .optional(),
+          hotspot: z
+            .object({
+              _type: z.literal("sanity.imageHotspot").optional(),
+              height: z.number(),
+              width: z.number(),
+              x: z.number(),
+              y: z.number(),
+            })
+            .optional(),
         }),
   } as unknown as ExtraZodFields<Hotspot>);
 


### PR DESCRIPTION
The current types enforce that `hotspot` and `crop` are always present on images when enabled, but hotspot and crop are optional in sanity when enabled. This PR makes hotspot and crop optional (**breaking change since one now needs to check if they're undefined in the application code**). This makes images work seamlessly with `@sanity/image-url`, even when new uploaded images haven't had a crop / hotspot set.