### PR TITLE
fix(schema): pass hotspot to schema options

### DIFF
--- a/src/image/index.spec.ts
+++ b/src/image/index.spec.ts
@@ -17,6 +17,9 @@ describe("image", () => {
   it("builds a sanity config", () =>
     expect(image().schema()).toEqual({
       type: "image",
+      options: {
+        hotspot: false,
+      },
     }));
 
   it("passes through schema values", () =>

--- a/src/image/index.spec.ts
+++ b/src/image/index.spec.ts
@@ -88,6 +88,13 @@ describe("image", () => {
     expect(parsedValue).toEqual(value);
   });
 
+  it("passes through hotspot to options object", () => {
+    const type = image({ hotspot: true });
+
+    expect(type.schema()).toHaveProperty("options");
+    expect(type.schema().options).toHaveProperty("hotspot", true);
+  });
+
   it("adds fields", () => {
     const type = image({
       fields: [

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -196,6 +196,9 @@ export const image = <
     schema: () => ({
       ...def,
       ...(fields && fieldsSchema(fields)),
+      ...(hotspot === true
+        ? { options: { ...def.options, hotspot: true } }
+        : {}),
       type: "image",
     }),
     zod: zodFn(

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -172,6 +172,7 @@ export const image = <
     zod as unknown as z.ZodType<ParsedValue, any, z.input<Zod>>,
   zodResolved = (zod) =>
     zod as unknown as z.ZodType<ResolvedValue, any, z.input<Zod>>,
+  options,
   ...def
 }: Merge<
   Omit<
@@ -196,9 +197,7 @@ export const image = <
     schema: () => ({
       ...def,
       ...(fields && fieldsSchema(fields)),
-      ...(hotspot === true
-        ? { options: { ...def.options, hotspot: true } }
-        : {}),
+      options: { ...options, hotspot: Boolean(hotspot) },
       type: "image",
     }),
     zod: zodFn(


### PR DESCRIPTION
Avoids having to specify hotspot twice, eg:
```typescript
s.image({hotspot: true});
```
instead of 
```typescript
s.image({hotspot: true, options: {hotspot: true});
```