### PR TITLE
Implement namedObjectArray using discriminatedUnion

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -5,6 +5,7 @@ export { createType } from "./types";
 export { date } from "./date";
 export { datetime } from "./datetime";
 export { document } from "./document";
+export { namedObjectArray } from "./namedObjectArray";
 export { file } from "./file";
 export { geopoint } from "./geopoint";
 export { image } from "./image";

--- a/src/namedObjectArray/index.spec.ts
+++ b/src/namedObjectArray/index.spec.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "@jest/globals";
+import { z } from "zod";
+
+import { boolean } from "../boolean";
+import { objectNamed } from "../objectNamed";
+import { mockRule } from "../test-utils";
+
+import { namedObjectArray } from ".";
+
+import type { ValidateShape } from "../test-utils";
+import type {
+  InferParsedValue,
+  InferResolvedValue,
+  InferValue,
+} from "../types";
+import type { Merge, PartialDeep } from "type-fest";
+
+const dummyObj = objectNamed({
+  name: "dummy",
+  fields: [
+    {
+      name: "foo",
+      type: boolean(),
+    },
+  ],
+});
+type dummyObjType = Merge<InferValue<typeof dummyObj>, { _key: string }>;
+
+const dummyObj2 = objectNamed({
+  name: "movie",
+  fields: [
+    {
+      name: "bar",
+      type: boolean(),
+    },
+  ],
+});
+const dummyObj3 = objectNamed({
+  name: "actor",
+  fields: [
+    {
+      name: "baz",
+      type: boolean(),
+    },
+  ],
+});
+
+describe("array", () => {
+  it("builds a sanity config", () =>
+    expect(namedObjectArray({ of: [dummyObj] }).schema()).toEqual({
+      type: "array",
+      of: [
+        {
+          type: "object",
+          name: "dummy",
+          fields: [
+            {
+              name: "foo",
+              type: "boolean",
+              validation: expect.any(Function),
+            },
+          ],
+          preview: undefined,
+        },
+      ],
+      validation: expect.any(Function),
+    }));
+
+  it("passes through schema values", () =>
+    expect(
+      namedObjectArray({ of: [dummyObj], hidden: false }).schema()
+    ).toHaveProperty("hidden", false));
+
+  it("adds document types", () => {
+    const type = namedObjectArray({ of: [dummyObj] });
+
+    const value: ValidateShape<
+      InferValue<typeof type>,
+      Array<{ _key: string; _type: "dummy"; foo: boolean }>
+    > = [
+      {
+        _type: "dummy",
+        _key: "a",
+        foo: true,
+      },
+    ];
+
+    const parsedValue: ValidateShape<
+      InferParsedValue<typeof type>,
+      Array<{ _key: string; _type: "dummy"; foo: boolean }>
+    > = type.parse(value);
+
+    expect(parsedValue).toEqual(value);
+  });
+
+  it("creates union with multiple named objects", () => {
+    const type = namedObjectArray({
+      of: [dummyObj, dummyObj2, dummyObj3],
+    });
+
+    const schema = type.schema();
+
+    expect(schema).toHaveProperty("of", [
+      {
+        type: "object",
+        name: "dummy",
+        preview: undefined,
+        fields: [
+          {
+            name: "foo",
+            type: "boolean",
+            validation: expect.any(Function),
+          },
+        ],
+      },
+      {
+        type: "object",
+        name: "movie",
+        preview: undefined,
+        fields: [
+          {
+            name: "bar",
+            type: "boolean",
+            validation: expect.any(Function),
+          },
+        ],
+      },
+      {
+        type: "object",
+        name: "actor",
+        preview: undefined,
+        fields: [
+          {
+            name: "baz",
+            type: "boolean",
+            validation: expect.any(Function),
+          },
+        ],
+      },
+    ]);
+
+    const value: ValidateShape<
+      InferValue<typeof type>,
+      Array<
+        | { _key: string; _type: "dummy"; foo: boolean }
+        | { _key: string; _type: "movie"; bar: boolean }
+        | { _key: string; _type: "actor"; baz: boolean }
+      >
+    > = [
+      { _type: "dummy", _key: "a", foo: true },
+      { _type: "movie", _key: "b", bar: true },
+      { _type: "actor", _key: "c", baz: true },
+    ];
+    const parsedValue: ValidateShape<
+      InferParsedValue<typeof type>,
+      Array<
+        | { _key: string; _type: "dummy"; foo: boolean }
+        | { _key: string; _type: "movie"; bar: boolean }
+        | { _key: string; _type: "actor"; baz: boolean }
+      >
+    > = type.parse(value);
+
+    expect(parsedValue).toEqual(value);
+  });
+
+  it("resolves into an array of objects", () => {
+    const type = namedObjectArray({
+      of: [
+        objectNamed({
+          name: "foo" as const,
+          fields: [
+            {
+              name: "foo",
+              type: boolean({
+                zodResolved: (zod) => zod.transform(() => "foo"),
+              }),
+            },
+          ],
+        }),
+      ],
+    });
+
+    const value: ValidateShape<
+      InferValue<typeof type>,
+      Array<{ _key: string; _type: "foo"; foo: boolean }>
+    > = [
+      {
+        _type: "foo" as const,
+        foo: true,
+        _key: "a",
+      },
+    ];
+    const resolvedValue: ValidateShape<
+      InferResolvedValue<typeof type>,
+      Array<{ _key: string; _type: "foo"; foo: string }>
+    > = type.resolve(value);
+
+    expect(resolvedValue).toEqual([{ _type: "foo", foo: "foo", _key: "a" }]);
+  });
+
+  it("sets min", () => {
+    const type = namedObjectArray({ min: 2, of: [dummyObj] });
+
+    const rule = mockRule();
+
+    type.schema().validation(rule);
+
+    expect(rule.min).toHaveBeenCalledWith(2);
+
+    const value: ValidateShape<
+      InferValue<typeof type>,
+      [dummyObjType, dummyObjType, ...dummyObjType[]]
+    > = [
+      { _type: "dummy" as const, foo: true, _key: "a" },
+      { _type: "dummy" as const, foo: false, _key: "b" },
+    ];
+    const parsedValue: ValidateShape<
+      InferParsedValue<typeof type>,
+      [dummyObjType, dummyObjType, ...dummyObjType[]]
+    > = type.parse(value);
+
+    expect(parsedValue).toEqual(value);
+
+    expect(() => {
+      type.parse([{ _type: "dummy", foo: true, _key: "a" }]);
+    }).toThrow(z.ZodError);
+  });
+
+  it("sets max", () => {
+    const type = namedObjectArray({ max: 3, of: [dummyObj] });
+
+    const rule = mockRule();
+
+    type.schema().validation(rule);
+
+    expect(rule.max).toHaveBeenCalledWith(3);
+
+    const value: ValidateShape<
+      InferValue<typeof type>,
+      | []
+      | [dummyObjType]
+      | [dummyObjType, dummyObjType]
+      | [dummyObjType, dummyObjType, dummyObjType]
+    > = [
+      { _type: "dummy", foo: true, _key: "a" },
+      { _type: "dummy", foo: false, _key: "a" },
+      { _type: "dummy", foo: true, _key: "a" },
+    ];
+    const parsedValue: ValidateShape<
+      InferParsedValue<typeof type>,
+      | []
+      | [dummyObjType]
+      | [dummyObjType, dummyObjType]
+      | [dummyObjType, dummyObjType, dummyObjType]
+    > = type.parse(value);
+
+    expect(parsedValue).toEqual(value);
+
+    expect(() => {
+      type.parse([
+        { _type: "dummy", foo: true, _key: "a" },
+        { _type: "dummy", foo: false, _key: "a" },
+        { _type: "dummy", foo: true, _key: "a" },
+        { _type: "dummy", foo: false, _key: "a" },
+      ]);
+    }).toThrow(z.ZodError);
+  });
+
+  it("sets length", () => {
+    const type = namedObjectArray({ length: 2, of: [dummyObj] });
+
+    const rule = mockRule();
+
+    type.schema().validation(rule);
+
+    expect(rule.length).toHaveBeenCalledWith(2);
+
+    const value: ValidateShape<
+      InferValue<typeof type>,
+      [dummyObjType, dummyObjType]
+    > = [
+      { _type: "dummy", foo: true, _key: "a" },
+      { _type: "dummy", foo: false, _key: "a" },
+    ];
+    const parsedValue: ValidateShape<
+      InferParsedValue<typeof type>,
+      [dummyObjType, dummyObjType]
+    > = type.parse(value);
+
+    expect(parsedValue).toEqual(value);
+
+    expect(() => {
+      type.parse([{ _type: "dummy", foo: true, _key: "a" }]);
+    }).toThrow(z.ZodError);
+
+    expect(() => {
+      type.parse([
+        { _type: "dummy", foo: true, _key: "a" },
+        { _type: "dummy", foo: false, _key: "a" },
+        { _type: "dummy", foo: true, _key: "a" },
+      ]);
+    }).toThrow(z.ZodError);
+  });
+
+  it("allows defining the zod", () => {
+    const type = namedObjectArray({
+      of: [
+        objectNamed({
+          name: "dummy",
+          fields: [
+            {
+              name: "foo",
+              type: boolean({
+                zod: (zod) => zod.transform((value) => (value ? 1 : 0)),
+              }),
+            },
+          ],
+        }),
+      ],
+      zod: (zod) =>
+        zod.transform((values) =>
+          values.reduce<number>((sum, val) => sum + val.foo, 0)
+        ),
+    });
+
+    const parsedValue: ValidateShape<
+      InferParsedValue<typeof type>,
+      number
+    > = type.parse([
+      { _type: "dummy", foo: true, _key: "a" },
+      { _type: "dummy", foo: false, _key: "a" },
+    ]);
+
+    expect(parsedValue).toEqual(1);
+  });
+
+  it("types custom validation", () => {
+    const type = namedObjectArray({
+      of: [dummyObj, dummyObj2],
+      validation: (Rule) =>
+        Rule.custom((value) => {
+          const elements: ValidateShape<
+            typeof value,
+            PartialDeep<
+              Array<
+                | { _key: string; _type: "dummy"; foo: boolean }
+                | { _key: string; _type: "movie"; bar: boolean }
+              >
+            >
+          > = value;
+
+          return elements.length > 50 || "Needs to be 50 characters";
+        }),
+    });
+
+    const rule = mockRule();
+
+    type.schema().validation(rule);
+
+    expect(rule.custom).toHaveBeenCalledWith(expect.any(Function));
+  });
+});

--- a/src/namedObjectArray/index.ts
+++ b/src/namedObjectArray/index.ts
@@ -1,0 +1,177 @@
+import { flow, map } from "lodash/fp";
+import { z } from "zod";
+
+import { createType, zodDiscriminatedUnion } from "../types";
+
+import type {
+  InferParsedValue,
+  InferResolvedValue,
+  InferValue,
+  Rule,
+  SanityType,
+  SanityTypeDef,
+  TupleOfLength,
+} from "../types";
+import type { Schema } from "@sanity/types";
+import type { Merge } from "type-fest";
+
+type AddKey<T> = T extends object ? Merge<T, { _key: string }> : T;
+
+const addKeyToZod = <Input, Output>(zod: z.ZodType<Output, any, Input>) =>
+  !(zod instanceof z.ZodObject)
+    ? (zod as z.ZodType<AddKey<Output>, any, AddKey<Input>>)
+    : (zod.extend({
+        _key: z.string(),
+      }) as unknown as z.ZodType<AddKey<Output>, any, AddKey<Input>>);
+
+type Precedence<A extends number, B extends number> = number extends A ? B : A;
+
+const zodArrayOfLength =
+  <Length extends number, Min extends number, Max extends number>({
+    length,
+    max,
+    min,
+  }: {
+    length?: Length;
+    max?: Max;
+    min?: Min;
+  }) =>
+  <Input, Output>(zods: Array<z.ZodType<Output, any, Input>>) =>
+    flow(
+      flow(
+        (value: typeof zods) => value,
+        map(addKeyToZod),
+        zodDiscriminatedUnion,
+        z.array,
+        (zod) => (!min ? zod : zod.min(min)),
+        (zod) => (!max ? zod : zod.max(max)),
+        (zod) => (length === undefined ? zod : zod.length(length))
+      ),
+      (zod) =>
+        zod as unknown as z.ZodType<
+          TupleOfLength<
+            AddKey<Output>,
+            Precedence<Length, Min>,
+            Precedence<Length, Max>
+          >,
+          any,
+          TupleOfLength<
+            AddKey<Input>,
+            Precedence<Length, Min>,
+            Precedence<Length, Max>
+          >
+        >
+    )(zods);
+
+export const namedObjectArray = <
+  ItemValue,
+  ParsedItemValue,
+  ResolvedItemValue,
+  ItemsArray extends TupleOfLength<
+    SanityType<
+      { name: string; type: string },
+      ItemValue,
+      ParsedItemValue,
+      ResolvedItemValue
+    >,
+    1
+  >,
+  Length extends number,
+  Min extends number,
+  Max extends number,
+  Value extends TupleOfLength<
+    AddKey<InferValue<ItemsArray[number]>>,
+    Precedence<Length, Min>,
+    Precedence<Length, Max>
+  >,
+  ParsedValue = TupleOfLength<
+    AddKey<InferParsedValue<ItemsArray[number]>>,
+    Precedence<Length, Min>,
+    Precedence<Length, Max>
+  >,
+  ResolvedValue = TupleOfLength<
+    AddKey<InferResolvedValue<ItemsArray[number]>>,
+    Precedence<Length, Min>,
+    Precedence<Length, Max>
+  >
+>({
+  length,
+  max,
+  min,
+  validation,
+  of: items,
+  // FIXME Mock the array element types. Not sure how to allow an override, since the function has to be defined before we know the element types.
+  mock = () => [] as unknown as Value,
+  zod: zodFn = (zod) => zod as unknown as z.ZodType<ParsedValue, any, Value>,
+  zodResolved = (zod) => zod as unknown as z.ZodType<ResolvedValue, any, Value>,
+  ...def
+}: Merge<
+  SanityTypeDef<
+    Schema.ArrayDefinition<Value[keyof Value]>,
+    Value,
+    ParsedValue,
+    ResolvedValue,
+    TupleOfLength<
+      AddKey<InferParsedValue<ItemsArray[number]>>,
+      Precedence<Length, Min>,
+      Precedence<Length, Max>
+    >,
+    TupleOfLength<
+      AddKey<InferResolvedValue<ItemsArray[number]>>,
+      Precedence<Length, Min>,
+      Precedence<Length, Max>
+    >
+  >,
+  {
+    length?: Length;
+    max?: Max;
+    min?: Min;
+    of: ItemsArray;
+  }
+>) =>
+  createType({
+    mock,
+    zod: zodFn(
+      flow(
+        (value: typeof items) => value,
+        map(
+          ({ zod }) =>
+            zod as z.ZodType<
+              InferParsedValue<ItemsArray[number]>,
+              any,
+              InferValue<ItemsArray[number]>
+            >
+        ),
+        zodArrayOfLength({ length, max, min }),
+        <Output>(value: z.ZodType<Output, any, any>) =>
+          value as z.ZodType<Output, any, Value>
+      )(items)
+    ),
+    zodResolved: zodResolved(
+      flow(
+        (value: typeof items) => value,
+        map(
+          ({ zodResolved }) =>
+            zodResolved as z.ZodType<
+              InferResolvedValue<ItemsArray[number]>,
+              any,
+              InferValue<ItemsArray[number]>
+            >
+        ),
+        zodArrayOfLength({ length, max, min }),
+        <Output>(value: z.ZodType<Output, any, any>) =>
+          value as z.ZodType<Output, any, Value>
+      )(items)
+    ),
+    schema: () => ({
+      ...def,
+      type: "array",
+      of: items.map(({ schema }) => schema()),
+      validation: flow(
+        (rule: Rule<Value>) => (!min ? rule : rule.min(min)),
+        (rule) => (!max ? rule : rule.max(max)),
+        (rule) => (length === undefined ? rule : rule.length(length)),
+        (rule) => validation?.(rule) ?? rule
+      ),
+    }),
+  });

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,17 @@ export const zodUnion = <Zods extends z.ZodTypeAny>(zods: Zods[]): Zods =>
     ? zods[0]!
     : (z.union([zods[0]!, zods[1]!, ...zods.slice(2)]) as unknown as Zods);
 
+export const zodDiscriminatedUnion = <Zods extends z.ZodObject<any>>(
+  zods: Zods[]
+): Zods =>
+  zods.length === 1
+    ? zods[0]!
+    : (z.discriminatedUnion("_type", [
+        zods[0]!,
+        zods[1]!,
+        ...zods.slice(2),
+      ]) as unknown as Zods);
+
 export interface SanityType<Definition, Value, ParsedValue, ResolvedValue> {
   mock: (faker: Faker, path?: string) => Value;
   parse: (data: unknown) => ParsedValue;


### PR DESCRIPTION
I added `namedObjectArray` using zod's discriminatedUnion, primarily for better error reporting when using a "page builder" array containing multiple different named objects, which i can only assume is fairly common practice in a CMS. At least we use it on all our pages, to allow editors to build pages visually via a live preview.

with `namedObjectArray` instead of `array` you get super concise errors pointing exactly to the problem, instead of thousands of lines (which grow with the amount of page "sections" you have in your array) which are impossible to reason about.

Hopefully it's useful to others, at least we can't really function without it :)